### PR TITLE
Deploy version metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,5 +186,5 @@ compile_commands.json
 # Eclipse generated file for annotation processors
 .factorypath
 
-# Version metadata file
-src/main/java/frc/robot/VersionConstants.java
+# Classes auto-generated at build time
+src/main/java/frc/robot/generated/

--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,6 @@ compile_commands.json
 
 # Eclipse generated file for annotation processors
 .factorypath
+
+# Version metadata file
+src/main/java/frc/robot/VersionConstants.java

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2025.2.1"
+	id "com.peterabeles.gversion" version "1.10"
 }
 
 java {
@@ -101,6 +102,17 @@ wpi.java.configureTestTasks(test)
 // Configure string concat to always inline compile
 tasks.withType(JavaCompile) {
     options.compilerArgs.add '-XDstringConcat=inline'
+}
+
+// Include Git metadata in deploy
+project.compileJava.dependsOn(createVersionFile)
+gversion {
+	srcDir       = "src/main/java/"
+	classPackage = "frc.robot"
+	className    = "VersionConstants"
+	dateFormat   = "yyyy-MM-dd HH:mm:ss z"
+	timeZone     = "America/Indiana/Indianapolis" // Use preferred time zone
+	indent       = "	"
 }
 
 // Build javadoc

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ gversion {
 
 // Build javadoc
 tasks.withType(Javadoc) {
+	exclude('**/generated/**')
 	options.tags('apiNote:a:API Note:')
 	options.tags('implSpec:a:Implementation Requirements:')
 	options.tags('implNote:a:Implementation Note:')

--- a/build.gradle
+++ b/build.gradle
@@ -108,8 +108,8 @@ tasks.withType(JavaCompile) {
 project.compileJava.dependsOn(createVersionFile)
 gversion {
 	srcDir       = "src/main/java/"
-	classPackage = "frc.robot"
-	className    = "VersionConstants"
+	classPackage = "frc.robot.generated"
+	className    = "VersionConstantsGenerated"
 	dateFormat   = "yyyy-MM-dd HH:mm:ss z"
 	timeZone     = "America/Indiana/Indianapolis" // Use preferred time zone
 	indent       = "	"

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -11,6 +11,7 @@ import frc.robot.util.DrivetrainUtil;
 import frc.robot.subsystems.Drivetrain;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.epilogue.Logged;
+import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
@@ -35,6 +36,9 @@ public class RobotContainer {
 
 	/** The container for the robot. Contains subsystems, OI devices, and commands. */
 	public RobotContainer() {
+		// Publish version metadata
+		VersionConstants.publishNetworkTables(NetworkTableInstance.getDefault().getTable("/Metadata"));
+
 		// Configure the trigger bindings
 		configureBindings();
 	}

--- a/src/main/java/frc/robot/VersionConstants.java
+++ b/src/main/java/frc/robot/VersionConstants.java
@@ -1,5 +1,7 @@
 package frc.robot;
 
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.StringPublisher;
 import frc.robot.generated.VersionConstantsGenerated;
 
 /**
@@ -55,4 +57,49 @@ public class VersionConstants {
 	 * Are there uncommited changes?
 	 */
 	public static final int DIRTY = VersionConstantsGenerated.DIRTY;
+
+	/**
+	 * Publish version metadata to a NetworkTable.
+	 *
+	 * @param table
+	 *            NetworkTable to publish metadata to.
+	 */
+	@SuppressWarnings("all")
+	public static void publishNetworkTables(NetworkTable table) {
+		StringPublisher mavenGroupPublisher = table.getStringTopic("/MavenGroup")
+				.publish();
+		mavenGroupPublisher.set(MAVEN_GROUP);
+
+		StringPublisher mavenNamePublisher = table.getStringTopic("/MavenName")
+				.publish();
+		mavenNamePublisher.set(MAVEN_NAME);
+
+		StringPublisher versionPublisher = table.getStringTopic("/Version")
+				.publish();
+		versionPublisher.set(VERSION);
+
+		StringPublisher gitRevisionPublisher = table.getStringTopic("/GitRevision")
+				.publish();
+		gitRevisionPublisher.set(String.valueOf(GIT_REVISION));
+
+		StringPublisher gitShaPublisher = table.getStringTopic("/GitSHA")
+				.publish();
+		gitShaPublisher.set(GIT_SHA);
+
+		StringPublisher gitDatePublisher = table.getStringTopic("/GitDate")
+				.publish();
+		gitDatePublisher.set(GIT_DATE);
+
+		StringPublisher gitBranchPublisher = table.getStringTopic("/GitBranch")
+				.publish();
+		gitBranchPublisher.set(GIT_BRANCH);
+
+		StringPublisher buildDatePublisher = table.getStringTopic("/BuildDate")
+				.publish();
+		buildDatePublisher.set(BUILD_DATE);
+
+		StringPublisher dirtyPublisher = table.getStringTopic("/Dirty")
+				.publish();
+		dirtyPublisher.set((DIRTY != 0) ? "Uncommited changes" : "All changes commited");
+	}
 }

--- a/src/main/java/frc/robot/VersionConstants.java
+++ b/src/main/java/frc/robot/VersionConstants.java
@@ -1,0 +1,58 @@
+package frc.robot;
+
+import frc.robot.generated.VersionConstantsGenerated;
+
+/**
+ * Constants that contain version metadata for the robot. Wraps an auto-generated class to add Javadoc and logging.
+ */
+public class VersionConstants {
+	/**
+	 * Maven group which the robot package belongs to.
+	 */
+	public static final String MAVEN_GROUP = VersionConstantsGenerated.MAVEN_GROUP;
+
+	/**
+	 * Maven package name of the robot package.
+	 */
+	public static final String MAVEN_NAME = VersionConstantsGenerated.MAVEN_NAME;
+
+	/**
+	 * Robot code version.
+	 */
+	public static final String VERSION = VersionConstantsGenerated.VERSION;
+
+	/**
+	 * Git revision number.
+	 */
+	public static final int GIT_REVISION = VersionConstantsGenerated.GIT_REVISION;
+
+	/**
+	 * Git commit hash.
+	 */
+	public static final String GIT_SHA = VersionConstantsGenerated.GIT_SHA;
+
+	/**
+	 * Git commit date.
+	 */
+	public static final String GIT_DATE = VersionConstantsGenerated.GIT_DATE;
+
+	/**
+	 * Git branch.
+	 */
+	public static final String GIT_BRANCH = VersionConstantsGenerated.GIT_BRANCH;
+
+	/**
+	 * Date on which the robot program was built in a human-readable format.
+	 */
+	public static final String BUILD_DATE = VersionConstantsGenerated.BUILD_DATE;
+
+	/**
+	 * Date on which the robot program was built in unix time.
+	 */
+	public static final long BUILD_UNIX_TIME = VersionConstantsGenerated.BUILD_UNIX_TIME;
+
+	/**
+	 * Are there uncommited changes?
+	 */
+	public static final int DIRTY = VersionConstantsGenerated.DIRTY;
+}


### PR DESCRIPTION
Generates a class which contains version metadata on build, which can be used to tell what version of the code is currently running on the robot.

@fodfodfod Can you add something that logs this over NetworkTables so we can see this metadata from the dashboard and in logs? We may want to publish this to the `/Metadata` table so it shows in the [Metadata tab](https://docs.advantagescope.org/tab-reference/metadata) in AdvantageScope.