### PR TITLE
Enable deleteOldFiles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,7 @@ deploy {
                 frcStaticFileDeploy(getArtifactTypeClass('FileTreeArtifact')) {
                     files = project.fileTree('src/main/deploy')
                     directory = '/home/lvuser/deploy'
-                    deleteOldFiles = false // Change to true to delete files on roboRIO that no
-                                           // longer exist in deploy directory of this project
+                    deleteOldFiles = true // Change to true to delete files on roboRIO that no longer exist in deploy directory of this project
                 }
             }
         }


### PR DESCRIPTION
Enables deleteOldFiles on deploy which will clear the deploy directory on the RIO on deploy.