### PR TITLE
Add simgui-ds.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,7 @@ out/
 # Simulation GUI and other tools window save file
 networktables.json
 simgui.json
+simgui-ds.json
 *-window.json
 
 # Simulation data log directory


### PR DESCRIPTION
I don't think I'll ever do anything with this (if anything, it will probably be the other files), so we should just add it to the .gitignore.