### PR TITLE
Fix snapback after pathfinding and after returning to heading control on Red

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -57,13 +57,7 @@ public class RobotContainer {
 	 */
 	public void teleopInit() {
 		// Reset the last angle so the robot doesn't try to spin.
-		if (Util.isRedAlliance()) {
-			// TODO: (Max) Does this work if you enable/disable as Red alliance multiple times? Won't it keep
-			// switing it by 180 degrees each time?
-			drivetrain.resetLastAngleScalarInverted();
-		} else {
-			drivetrain.resetLastAngleScalar();
-		}
+		drivetrain.resetLastAngleScalarByAlliance();
 	}
 
 	/**
@@ -78,7 +72,7 @@ public class RobotContainer {
 	private void configureBindings() {
 		// Set the default drivetrain command (used for the driver controller)
 		drivetrain.setDefaultCommand(!RobotBase.isSimulation() ? driveFieldOrientedDirectAngle : driveFieldOrientedDirectAngleSim);
-		driverController.leftBumper().whileTrue(driveFieldOrientedAnglularVelocity.finallyDo(drivetrain::resetLastAngleScalar));
+		driverController.leftBumper().whileTrue(driveFieldOrientedAnglularVelocity.finallyDo(drivetrain::resetLastAngleScalarByAlliance));
 		// TODO: (Max) This lets the driver move to the closest reef tag but how do they make it go to the
 		// left or right reef branch of that tag? What if they are on the right side of the tag but
 		// want to drive to the left branch?

--- a/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
@@ -350,6 +350,9 @@ public class Drivetrain extends SubsystemBase {
 
 	/**
 	 * The method to reset what the heading control will turn to if no angle is inputed. Used to prevent angle snapback.
+	 *
+	 * @implNote
+	 *           Running this on the Red alliance will cause the robot to flip 180 degrees. Call {@link #resetLastAngleScalarByAlliance()} instead if that is not the desired behavior.
 	 */
 	public void resetLastAngleScalar() {
 		swerveDrive.swerveController.lastAngleScalar = getHeading().getRadians();
@@ -370,6 +373,8 @@ public class Drivetrain extends SubsystemBase {
 	 * Inverted method to reset what the heading control will turn to if no angle is inputed. Used to prevent angle snapback.
 	 *
 	 * @see #resetLastAngleScalar()
+	 * @implNote
+	 *           Running this on the Blue alliance will cause the robot to flip 180 degrees. Call {@link #resetLastAngleScalarByAlliance()} instead if that is not the desired behavior.
 	 */
 	public void resetLastAngleScalarInverted() {
 		swerveDrive.swerveController.lastAngleScalar = getHeading().rotateBy(Rotation2d.k180deg).getRadians();


### PR DESCRIPTION
Creates a new resetLastAngleScalarByAlliance method that resets the last angle scalar, inverting the angle when on the Red alliance, and runs it after pathfinding and when returning to heading control. This is the same thing that was being done in teleopInit before, but now it is being used everywhere, since calling resetLastAngleScalar on the Red alliance at any time causes the robot to flip 180 degrees.