### PR TITLE
Add separate left and right Coral scoring poses

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -263,15 +263,23 @@ public final class Constants {
 			/**
 			 * Offset from the AprilTag from which scoring should happen.
 			 */
-			public static final Transform2d SCORING_OFFSET = new Transform2d(Meters.of(0.33 / 2), Meters.of(0.5), new Rotation2d(0));
+			public static final Transform2d SCORING_OFFSET = new Transform2d(Meters.of(0.33 / 2), Meters.of(0.5), Rotation2d.k180deg);
 			/**
-			 * Poses from which the robot can score on the blue alliance.
+			 * Poses from which the robot can score coral on the left side on the blue alliance.
 			 */
-			public static final List<Pose2d> SCORING_POSES_BLUE = new ArrayList<Pose2d>();
+			public static final List<Pose2d> CORAL_SCORING_POSES_BLUE_LEFT = new ArrayList<Pose2d>();
 			/**
-			 * Poses from which the robot can score on the red alliance.
+			 * Poses from which the robot can score coral on the right side on the blue alliance.
 			 */
-			public static final List<Pose2d> SCORING_POSES_RED = new ArrayList<Pose2d>();
+			public static final List<Pose2d> CORAL_SCORING_POSES_BLUE_RIGHT = new ArrayList<Pose2d>();
+			/**
+			 * Poses from which the robot can score coral on the left side on the red alliance.
+			 */
+			public static final List<Pose2d> CORAL_SCORING_POSES_RED_LEFT = new ArrayList<Pose2d>();
+			/**
+			 * Poses from which the robot can score coral on the right side on the red alliance.
+			 */
+			public static final List<Pose2d> CORAL_SCORING_POSES_RED_RIGHT = new ArrayList<Pose2d>();
 
 			static {
 				// Generate a list of tag poses.
@@ -283,20 +291,21 @@ public final class Constants {
 					}
 				});
 
-				// Generate a list of scoring poses.
+				// Generate lists of scoring poses.
 				TAG_POSES.forEach((pose) -> {
 					Pose2d pose2d = pose.toPose2d();
-					// TODO: (Max) Should be CORAL_SCORING_POSES_BLUE as for coral only, not algae. Correct?
-					// TODO: (Max) What is "regular" vs "flipped" side? Is it right or left reef branch?
 					// Regular side
-					SCORING_POSES_BLUE.add(pose2d.transformBy(SCORING_OFFSET));
+					CORAL_SCORING_POSES_BLUE_RIGHT.add(pose2d.transformBy(SCORING_OFFSET));
 					// Flipped side
-					SCORING_POSES_BLUE.add(pose2d.transformBy(new Transform2d(SCORING_OFFSET.getMeasureX(), SCORING_OFFSET.getMeasureY().times(-1), SCORING_OFFSET.getRotation())));
+					CORAL_SCORING_POSES_BLUE_LEFT.add(pose2d.transformBy(new Transform2d(SCORING_OFFSET.getMeasureX(), SCORING_OFFSET.getMeasureY().times(-1), SCORING_OFFSET.getRotation())));
 				});
 
-				// Generate a list of scoring poses for the other alliance.
-				SCORING_POSES_BLUE.forEach((pose) -> {
-					SCORING_POSES_RED.add(PoseUtil.flipPose(pose));
+				// Generate lists of scoring poses for the other alliance.
+				CORAL_SCORING_POSES_BLUE_LEFT.forEach((pose) -> {
+					CORAL_SCORING_POSES_RED_LEFT.add(PoseUtil.flipPose(pose));
+				});
+				CORAL_SCORING_POSES_BLUE_RIGHT.forEach((pose) -> {
+					CORAL_SCORING_POSES_RED_RIGHT.add(PoseUtil.flipPose(pose));
 				});
 			}
 		}

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -79,7 +79,10 @@ public class RobotContainer {
 		// left or right reef branch of that tag? What if they are on the right side of the tag but
 		// want to drive to the left branch?
 		// TODO: (Max) Shouldn't this be a whileTrue to allow them to cancel the command if not longer desired?
-		driverController.x().onTrue(Commands.either(drivetrain.driveToNearestPoseCommand(FieldConstants.Reef.SCORING_POSES_RED), drivetrain.driveToNearestPoseCommand(FieldConstants.Reef.SCORING_POSES_BLUE), () -> Util.isRedAlliance()));
+		driverController.x()
+				.onTrue(Commands.either(drivetrain.driveToNearestPoseCommand(FieldConstants.Reef.CORAL_SCORING_POSES_RED_LEFT), drivetrain.driveToNearestPoseCommand(FieldConstants.Reef.CORAL_SCORING_POSES_BLUE_LEFT), () -> Util.isRedAlliance()));
+		driverController.y()
+				.onTrue(Commands.either(drivetrain.driveToNearestPoseCommand(FieldConstants.Reef.CORAL_SCORING_POSES_RED_RIGHT), drivetrain.driveToNearestPoseCommand(FieldConstants.Reef.CORAL_SCORING_POSES_BLUE_RIGHT), () -> Util.isRedAlliance()));
 		// TODO: (Max) How does a driver have it align/drive to the 1) coral station and 2) processor?
 
 		// TODO: transfer to dashboard

--- a/src/main/java/frc/robot/util/PoseUtil.java
+++ b/src/main/java/frc/robot/util/PoseUtil.java
@@ -1,6 +1,7 @@
 package frc.robot.util;
 
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import frc.robot.Constants.FieldConstants;
 
@@ -17,10 +18,7 @@ public class PoseUtil {
 	 *         Flipped pose.
 	 */
 	public static Pose2d flipPose(Pose2d pose) {
-		// TODO: (Max) If you are flipping between alliances, don't you also need to flip the rotation?
-		// Think about if you are facing the reef on the blue side, if you flip to be facing the reef on the
-		// red side you need to change the rotation
-		return new Pose2d(flipTranslation(pose.getTranslation()), pose.getRotation());
+		return new Pose2d(flipTranslation(pose.getTranslation()), pose.getRotation().rotateBy(Rotation2d.k180deg));
 	}
 
 	/**
@@ -32,7 +30,6 @@ public class PoseUtil {
 	 *         Flipped translation.
 	 */
 	public static Translation2d flipTranslation(Translation2d translation) {
-		// TODO: (Max) I think you need to also adjust the Y coordinate. Look at a field map
-		return new Translation2d(FieldConstants.FIELD_LAYOUT.getFieldLength() - translation.getX(), translation.getY());
+		return new Translation2d(FieldConstants.FIELD_LAYOUT.getFieldLength() - translation.getX(), FieldConstants.FIELD_LAYOUT.getFieldWidth() - translation.getY());
 	}
 }


### PR DESCRIPTION
Adds separate sets of Coral scoring poses for the left and right sides of the reef. Also fixes some problems with the pose flipping.