### PR TITLE
Bring Robot class up to coding standards

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -20,9 +20,14 @@ import frc.robot.Constants.LoggingConstants;
  */
 @Logged
 public class Robot extends TimedRobot {
-	private Command m_autonomousCommand;
-
-	private final RobotContainer m_robotContainer;
+	/**
+	 * Command that contains the autonomous routine. Set and run at the start of {@link #autonomousInit()}.
+	 */
+	private Command autonomousCommand;
+	/**
+	 * Class that contains most of the robot initialization and control logic.
+	 */
+	private final RobotContainer robotContainer;
 
 	/**
 	 * This function is run when the robot is first started up and should be used for any
@@ -42,7 +47,7 @@ public class Robot extends TimedRobot {
 		Epilogue.bind(this);
 		// Instantiate our RobotContainer. This will perform all our button bindings, and put our
 		// autonomous chooser on the dashboard.
-		m_robotContainer = new RobotContainer();
+		robotContainer = new RobotContainer();
 	}
 
 	/**
@@ -71,11 +76,11 @@ public class Robot extends TimedRobot {
 	/** This autonomous runs the autonomous command selected by your {@link RobotContainer} class. */
 	@Override
 	public void autonomousInit() {
-		m_autonomousCommand = m_robotContainer.getAutonomousCommand();
+		autonomousCommand = robotContainer.getAutonomousCommand();
 
 		// schedule the autonomous command (example)
-		if (m_autonomousCommand != null) {
-			m_autonomousCommand.schedule();
+		if (autonomousCommand != null) {
+			autonomousCommand.schedule();
 		}
 	}
 
@@ -85,14 +90,14 @@ public class Robot extends TimedRobot {
 
 	@Override
 	public void teleopInit() {
-		m_robotContainer.teleopInit();
+		robotContainer.teleopInit();
 
 		// This makes sure that the autonomous stops running when
 		// teleop starts running. If you want the autonomous to
 		// continue until interrupted by another command, remove
 		// this line or comment it out.
-		if (m_autonomousCommand != null) {
-			m_autonomousCommand.cancel();
+		if (autonomousCommand != null) {
+			autonomousCommand.cancel();
 		}
 	}
 


### PR DESCRIPTION
Removes the `m_` prefix from m_autonomousCommand and m_robotContainer, and adds Javadoc to both. This will change the paths of logged data which will make it slightly harder to compare old log files with new ones, but as long as we merge this soon it should be fine because we don't really have much of any useful data logged yet.