### PR TITLE
Add a zeroGyroCommand to Drivetrain

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -87,7 +87,7 @@ public class RobotContainer {
 		driverController.a().whileTrue(drivetrain.lockCommand());
 
 		// TODO: transfer to dashboard
-		driverController.start().onTrue(Commands.runOnce(() -> drivetrain.zeroGyro(), drivetrain));
+		driverController.start().onTrue(drivetrain.zeroGyroCommand());
 		driverController.back().onTrue(drivetrain.centerModulesCommand());
 	}
 

--- a/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
@@ -234,11 +234,20 @@ public class Drivetrain extends SubsystemBase {
 	/**
 	 * Resets the gyro angle to zero and resets odometry to the same position, but facing toward 0.
 	 *
-	 * @see
-	 *      SwerveDrive#zeroGyro()
+	 * @see SwerveDrive#zeroGyro()
 	 */
 	public void zeroGyro() {
 		swerveDrive.zeroGyro();
+	}
+
+	/**
+	 * Resets the gyro angle to zero and resets odometry to the same position, but facing toward 0.
+	 *
+	 * @see #zeroGyro()
+	 */
+	public Command zeroGyroCommand() {
+		return Commands.runOnce(() -> zeroGyro(), this)
+				.ignoringDisable(true);
 	}
 
 	/**


### PR DESCRIPTION
Add a zeroGyroCommand to Drivetrain, which resets the gyro and can be run while disabled.