### PR TITLE
Comment out the PDH logging

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -31,8 +31,8 @@ public class Robot extends TimedRobot {
 	 */
 	private final RobotContainer robotContainer;
 
-	@Logged
-	private final PowerDistribution pdh = new PowerDistribution();
+	// @Logged
+	// private final PowerDistribution pdh = new PowerDistribution();
 
 	/**
 	 * This function is run when the robot is first started up and should be used for any


### PR DESCRIPTION
Disable the PDH logging because it throws CAN-related errors, causing the robot code to crash.