### PR TITLE
Show build metadata on dashboard

### DIFF
--- a/src/main/deploy/elastic-layout.json
+++ b/src/main/deploy/elastic-layout.json
@@ -49,7 +49,7 @@
             "height": 128.0,
             "type": "Text Display",
             "properties": {
-              "topic": "/Metadata//BuildDate",
+              "topic": "/Metadata/BuildDate",
               "period": 0.06,
               "data_type": "string",
               "show_submit_button": false
@@ -184,6 +184,153 @@
             }
           }
         ]
+      }
+    },
+    {
+      "name": "Metadata",
+      "grid_layout": {
+        "layouts": [
+          {
+            "title": "Metadata",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 640.0,
+            "height": 640.0,
+            "type": "List Layout",
+            "properties": {
+              "label_position": "TOP"
+            },
+            "children": [
+              {
+                "title": "BuildDate",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Metadata/BuildDate",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "Dirty",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Metadata/Dirty",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "GitBranch",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Metadata/GitBranch",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "GitDate",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Metadata/GitDate",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "GitRevision",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Metadata/GitRevision",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "GitSHA",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Metadata/GitSHA",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "MavenGroup",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Metadata/MavenGroup",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "MavenName",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Metadata/MavenName",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "Version",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/Metadata/Version",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              }
+            ]
+          }
+        ],
+        "containers": []
       }
     },
     {

--- a/src/main/java/frc/robot/VersionConstants.java
+++ b/src/main/java/frc/robot/VersionConstants.java
@@ -66,39 +66,39 @@ public class VersionConstants {
 	 */
 	@SuppressWarnings("all")
 	public static void publishNetworkTables(NetworkTable table) {
-		StringPublisher mavenGroupPublisher = table.getStringTopic("/MavenGroup")
+		StringPublisher mavenGroupPublisher = table.getStringTopic("MavenGroup")
 				.publish();
 		mavenGroupPublisher.set(MAVEN_GROUP);
 
-		StringPublisher mavenNamePublisher = table.getStringTopic("/MavenName")
+		StringPublisher mavenNamePublisher = table.getStringTopic("MavenName")
 				.publish();
 		mavenNamePublisher.set(MAVEN_NAME);
 
-		StringPublisher versionPublisher = table.getStringTopic("/Version")
+		StringPublisher versionPublisher = table.getStringTopic("Version")
 				.publish();
 		versionPublisher.set(VERSION);
 
-		StringPublisher gitRevisionPublisher = table.getStringTopic("/GitRevision")
+		StringPublisher gitRevisionPublisher = table.getStringTopic("GitRevision")
 				.publish();
 		gitRevisionPublisher.set(String.valueOf(GIT_REVISION));
 
-		StringPublisher gitShaPublisher = table.getStringTopic("/GitSHA")
+		StringPublisher gitShaPublisher = table.getStringTopic("GitSHA")
 				.publish();
 		gitShaPublisher.set(GIT_SHA);
 
-		StringPublisher gitDatePublisher = table.getStringTopic("/GitDate")
+		StringPublisher gitDatePublisher = table.getStringTopic("GitDate")
 				.publish();
 		gitDatePublisher.set(GIT_DATE);
 
-		StringPublisher gitBranchPublisher = table.getStringTopic("/GitBranch")
+		StringPublisher gitBranchPublisher = table.getStringTopic("GitBranch")
 				.publish();
 		gitBranchPublisher.set(GIT_BRANCH);
 
-		StringPublisher buildDatePublisher = table.getStringTopic("/BuildDate")
+		StringPublisher buildDatePublisher = table.getStringTopic("BuildDate")
 				.publish();
 		buildDatePublisher.set(BUILD_DATE);
 
-		StringPublisher dirtyPublisher = table.getStringTopic("/Dirty")
+		StringPublisher dirtyPublisher = table.getStringTopic("Dirty")
 				.publish();
 		dirtyPublisher.set((DIRTY != 0) ? "Uncommited changes" : "All changes commited");
 	}


### PR DESCRIPTION
Adds a dashboard tab that displays the Metadata NetworkTable. Also removes the leading slashes from the Metadata entries so they display properly in Elastic and AdvantageScope (they were being shown under a table with a blank name in Elastic and were being shown with leading slashes before their names in AdvantageScope).

This has been tested to work in simulation, and ideally this should be merged before the first competition so our NetworkTable names are consistent across different logs.