### PR TITLE
Add scoring poses for the coral station

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -706,7 +706,7 @@ public final class Constants {
 			/**
 			 * Offset from the AprilTag from which coral scoring into L4 should happen.
 			 */
-			public static final Transform2d CORAL_SCORING_OFFSET_L4 = new Transform2d(Meters.of(2.5), Meters.of(0.33 / 2), Rotation2d.k180deg);
+			public static final Transform2d CORAL_SCORING_OFFSET_L4 = new Transform2d(Meters.of(2.5), CORAL_SCORING_OFFSET.getMeasureY(), Rotation2d.k180deg);
 			/**
 			 * Offset from the AprilTag from which algae scoring should happen.
 			 */

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -700,11 +700,11 @@ public final class Constants {
 			 */
 			public static final List<Pose3d> TAG_POSES = new ArrayList<Pose3d>();
 			/**
-			 * Offset from the AprilTag from which coral scoring should happen.
+			 * Offset from the AprilTag from which coral scoring should happen on the right side.
 			 */
 			public static final Transform2d CORAL_SCORING_OFFSET = new Transform2d(Meters.of(0.5), Meters.of(0.33 / 2), Rotation2d.k180deg);
 			/**
-			 * Offset from the AprilTag from which coral scoring into L4 should happen.
+			 * Offset from the AprilTag from which coral scoring into L4 should happen on the right side.
 			 */
 			public static final Transform2d CORAL_SCORING_OFFSET_L4 = new Transform2d(Meters.of(0.6), CORAL_SCORING_OFFSET.getMeasureY(), Rotation2d.k180deg);
 			/**
@@ -768,12 +768,12 @@ public final class Constants {
 
 					// Regular side
 					CORAL_SCORING_POSES_BLUE_RIGHT.add(pose2d.transformBy(CORAL_SCORING_OFFSET));
-					// Flipped side
+					// Mirrored side
 					CORAL_SCORING_POSES_BLUE_LEFT.add(pose2d.transformBy(PoseUtil.flipTransformY(CORAL_SCORING_OFFSET)));
 
 					// Regular side (L4)
 					CORAL_SCORING_POSES_L4_BLUE_RIGHT.add(pose2d.transformBy(CORAL_SCORING_OFFSET_L4));
-					// Flipped side (L4)
+					// Mirrored side (L4)
 					CORAL_SCORING_POSES_L4_BLUE_LEFT.add(pose2d.transformBy(PoseUtil.flipTransformY(CORAL_SCORING_OFFSET_L4)));
 				});
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -898,55 +898,35 @@ public final class Constants {
 
 		static {
 			// Compile CORAL_SCORING_POSES_BLUE_LEFT poses
-			FieldConstants.Reef.CORAL_SCORING_POSES_BLUE_LEFT.forEach((pose) -> {
-				CORAL_SCORING_POSES_BLUE_LEFT.add(pose);
-			});
+			CORAL_SCORING_POSES_BLUE_LEFT.addAll(FieldConstants.Reef.CORAL_SCORING_POSES_BLUE_LEFT);
 
 			// Compile CORAL_SCORING_POSES_BLUE_RIGHT poses
-			FieldConstants.Reef.CORAL_SCORING_POSES_BLUE_RIGHT.forEach((pose) -> {
-				CORAL_SCORING_POSES_BLUE_RIGHT.add(pose);
-			});
+			CORAL_SCORING_POSES_BLUE_RIGHT.addAll(FieldConstants.Reef.CORAL_SCORING_POSES_BLUE_RIGHT);
 
 			// Compile CORAL_SCORING_POSES_RED_LEFT poses
-			FieldConstants.Reef.CORAL_SCORING_POSES_RED_LEFT.forEach((pose) -> {
-				CORAL_SCORING_POSES_RED_LEFT.add(pose);
-			});
+			CORAL_SCORING_POSES_RED_LEFT.addAll(FieldConstants.Reef.CORAL_SCORING_POSES_RED_LEFT);
 
 			// Compile CORAL_SCORING_POSES_RED_RIGHT poses
-			FieldConstants.Reef.CORAL_SCORING_POSES_RED_RIGHT.forEach((pose) -> {
-				CORAL_SCORING_POSES_RED_RIGHT.add(pose);
-			});
+			CORAL_SCORING_POSES_RED_RIGHT.addAll(FieldConstants.Reef.CORAL_SCORING_POSES_RED_RIGHT);
 
 			// Compile CORAL_SCORING_POSES_L4_BLUE_LEFT poses
-			FieldConstants.Reef.CORAL_SCORING_POSES_L4_BLUE_LEFT.forEach((pose) -> {
-				CORAL_SCORING_POSES_L4_BLUE_LEFT.add(pose);
-			});
+			CORAL_SCORING_POSES_L4_BLUE_LEFT.addAll(FieldConstants.Reef.CORAL_SCORING_POSES_L4_BLUE_LEFT);
 
 			// Compile CORAL_SCORING_POSES_L4_BLUE_RIGHT poses
-			FieldConstants.Reef.CORAL_SCORING_POSES_L4_BLUE_RIGHT.forEach((pose) -> {
-				CORAL_SCORING_POSES_L4_BLUE_RIGHT.add(pose);
-			});
+			CORAL_SCORING_POSES_L4_BLUE_RIGHT.addAll(FieldConstants.Reef.CORAL_SCORING_POSES_L4_BLUE_RIGHT);
 
 			// Compile CORAL_SCORING_POSES_L4_RED_LEFT poses
-			FieldConstants.Reef.CORAL_SCORING_POSES_L4_RED_LEFT.forEach((pose) -> {
-				CORAL_SCORING_POSES_L4_RED_LEFT.add(pose);
-			});
+			CORAL_SCORING_POSES_L4_RED_LEFT.addAll(FieldConstants.Reef.CORAL_SCORING_POSES_L4_RED_LEFT);
 
 			// Compile CORAL_SCORING_POSES_L4_RED_RIGHT poses
-			FieldConstants.Reef.CORAL_SCORING_POSES_L4_RED_RIGHT.forEach((pose) -> {
-				CORAL_SCORING_POSES_L4_RED_RIGHT.add(pose);
-			});
+			CORAL_SCORING_POSES_L4_RED_RIGHT.addAll(FieldConstants.Reef.CORAL_SCORING_POSES_L4_RED_RIGHT);
 
 			// Compile ALGAE_SCORING_POSES_BLUE poses
-			FieldConstants.Reef.ALGAE_SCORING_POSES_BLUE.forEach((pose) -> {
-				ALGAE_SCORING_POSES_BLUE.add(pose);
-			});
+			ALGAE_SCORING_POSES_BLUE.addAll(FieldConstants.Reef.ALGAE_SCORING_POSES_BLUE);
 			ALGAE_SCORING_POSES_BLUE.add(FieldConstants.Processor.ALGAE_SCORING_POSE_BLUE);
 
 			// Compile ALGAE_SCORING_POSES_RED poses
-			FieldConstants.Reef.ALGAE_SCORING_POSES_RED.forEach((pose) -> {
-				ALGAE_SCORING_POSES_RED.add(pose);
-			});
+			ALGAE_SCORING_POSES_RED.addAll(FieldConstants.Reef.ALGAE_SCORING_POSES_RED);
 			ALGAE_SCORING_POSES_RED.add(FieldConstants.Processor.ALGAE_SCORING_POSE_RED);
 		}
 	}

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -769,28 +769,28 @@ public final class Constants {
 					// Regular side
 					CORAL_SCORING_POSES_BLUE_RIGHT.add(pose2d.transformBy(CORAL_SCORING_OFFSET));
 					// Flipped side
-					CORAL_SCORING_POSES_BLUE_LEFT.add(pose2d.transformBy(new Transform2d(CORAL_SCORING_OFFSET.getMeasureX(), CORAL_SCORING_OFFSET.getMeasureY().times(-1), CORAL_SCORING_OFFSET.getRotation())));
+					CORAL_SCORING_POSES_BLUE_LEFT.add(pose2d.transformBy(PoseUtil.flipTransformY(CORAL_SCORING_OFFSET)));
 
 					// Regular side (L4)
 					CORAL_SCORING_POSES_L4_BLUE_RIGHT.add(pose2d.transformBy(CORAL_SCORING_OFFSET_L4));
 					// Flipped side (L4)
-					CORAL_SCORING_POSES_L4_BLUE_LEFT.add(pose2d.transformBy(new Transform2d(CORAL_SCORING_OFFSET_L4.getMeasureX(), CORAL_SCORING_OFFSET_L4.getMeasureY().times(-1), CORAL_SCORING_OFFSET_L4.getRotation())));
+					CORAL_SCORING_POSES_L4_BLUE_LEFT.add(pose2d.transformBy(PoseUtil.flipTransformY(CORAL_SCORING_OFFSET_L4)));
 				});
 
 				// Generate lists of coral scoring poses for the other alliance.
 				CORAL_SCORING_POSES_BLUE_LEFT.forEach((pose) -> {
-					CORAL_SCORING_POSES_RED_LEFT.add(PoseUtil.flipPose(pose));
+					CORAL_SCORING_POSES_RED_LEFT.add(PoseUtil.flipPoseAlliance(pose));
 				});
 				CORAL_SCORING_POSES_BLUE_RIGHT.forEach((pose) -> {
-					CORAL_SCORING_POSES_RED_RIGHT.add(PoseUtil.flipPose(pose));
+					CORAL_SCORING_POSES_RED_RIGHT.add(PoseUtil.flipPoseAlliance(pose));
 				});
 
 				// Generate lists of coral scoring poses for L4 for the other alliance.
 				CORAL_SCORING_POSES_L4_BLUE_LEFT.forEach((pose) -> {
-					CORAL_SCORING_POSES_L4_RED_LEFT.add(PoseUtil.flipPose(pose));
+					CORAL_SCORING_POSES_L4_RED_LEFT.add(PoseUtil.flipPoseAlliance(pose));
 				});
 				CORAL_SCORING_POSES_L4_BLUE_RIGHT.forEach((pose) -> {
-					CORAL_SCORING_POSES_L4_RED_RIGHT.add(PoseUtil.flipPose(pose));
+					CORAL_SCORING_POSES_L4_RED_RIGHT.add(PoseUtil.flipPoseAlliance(pose));
 				});
 
 				// Generate a list of algae scoring poses.
@@ -801,7 +801,7 @@ public final class Constants {
 
 				// Generate a list of algae scoring poses for the other alliance.
 				ALGAE_SCORING_POSES_BLUE.forEach((pose) -> {
-					ALGAE_SCORING_POSES_RED.add(PoseUtil.flipPose(pose));
+					ALGAE_SCORING_POSES_RED.add(PoseUtil.flipPoseAlliance(pose));
 				});
 			}
 		}
@@ -845,7 +845,7 @@ public final class Constants {
 				Pose2d pose2d = TAG_POSE.toPose2d();
 
 				ALGAE_SCORING_POSE_BLUE = pose2d.transformBy(SCORING_OFFSET);
-				ALGAE_SCORING_POSE_RED = PoseUtil.flipPose(ALGAE_SCORING_POSE_BLUE);
+				ALGAE_SCORING_POSE_RED = PoseUtil.flipPoseAlliance(ALGAE_SCORING_POSE_BLUE);
 			}
 		}
 	}

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -704,6 +704,10 @@ public final class Constants {
 			 */
 			public static final Transform2d CORAL_SCORING_OFFSET = new Transform2d(Meters.of(0.5), Meters.of(0.33 / 2), Rotation2d.k180deg);
 			/**
+			 * Offset from the AprilTag from which coral scoring into L4 should happen.
+			 */
+			public static final Transform2d CORAL_SCORING_OFFSET_L4 = new Transform2d(Meters.of(2.5), Meters.of(0.33 / 2), Rotation2d.k180deg);
+			/**
 			 * Offset from the AprilTag from which algae scoring should happen.
 			 */
 			public static final Transform2d ALGAE_SCORING_OFFSET = new Transform2d(Meters.of(0.5), Meters.of(0), Rotation2d.k180deg);
@@ -723,6 +727,22 @@ public final class Constants {
 			 * Poses from which the robot can score coral on the right side on the red alliance.
 			 */
 			public static final List<Pose2d> CORAL_SCORING_POSES_RED_RIGHT = new ArrayList<Pose2d>();
+			/**
+			 * Poses from which the robot can score coral in L4 on the left side on the blue alliance.
+			 */
+			public static final List<Pose2d> CORAL_SCORING_POSES_L4_BLUE_LEFT = new ArrayList<Pose2d>();
+			/**
+			 * Poses from which the robot can score coral in L4 on the right side on the blue alliance.
+			 */
+			public static final List<Pose2d> CORAL_SCORING_POSES_L4_BLUE_RIGHT = new ArrayList<Pose2d>();
+			/**
+			 * Poses from which the robot can score coral in L4 on the left side on the red alliance.
+			 */
+			public static final List<Pose2d> CORAL_SCORING_POSES_L4_RED_LEFT = new ArrayList<Pose2d>();
+			/**
+			 * Poses from which the robot can score coral in L4 on the right side on the red alliance.
+			 */
+			public static final List<Pose2d> CORAL_SCORING_POSES_L4_RED_RIGHT = new ArrayList<Pose2d>();
 			/**
 			 * Poses from which the robot can score algae on the blue alliance.
 			 */
@@ -745,10 +765,16 @@ public final class Constants {
 				// Generate lists of coral scoring poses.
 				TAG_POSES.forEach((pose) -> {
 					Pose2d pose2d = pose.toPose2d();
+
 					// Regular side
 					CORAL_SCORING_POSES_BLUE_RIGHT.add(pose2d.transformBy(CORAL_SCORING_OFFSET));
 					// Flipped side
 					CORAL_SCORING_POSES_BLUE_LEFT.add(pose2d.transformBy(new Transform2d(CORAL_SCORING_OFFSET.getMeasureX(), CORAL_SCORING_OFFSET.getMeasureY().times(-1), CORAL_SCORING_OFFSET.getRotation())));
+
+					// Regular side (L4)
+					CORAL_SCORING_POSES_L4_BLUE_RIGHT.add(pose2d.transformBy(CORAL_SCORING_OFFSET_L4));
+					// Flipped side (L4)
+					CORAL_SCORING_POSES_L4_BLUE_LEFT.add(pose2d.transformBy(new Transform2d(CORAL_SCORING_OFFSET_L4.getMeasureX(), CORAL_SCORING_OFFSET_L4.getMeasureY().times(-1), CORAL_SCORING_OFFSET_L4.getRotation())));
 				});
 
 				// Generate lists of coral scoring poses for the other alliance.
@@ -757,6 +783,14 @@ public final class Constants {
 				});
 				CORAL_SCORING_POSES_BLUE_RIGHT.forEach((pose) -> {
 					CORAL_SCORING_POSES_RED_RIGHT.add(PoseUtil.flipPose(pose));
+				});
+
+				// Generate lists of coral scoring poses for L4 for the other alliance.
+				CORAL_SCORING_POSES_L4_BLUE_LEFT.forEach((pose) -> {
+					CORAL_SCORING_POSES_L4_RED_LEFT.add(PoseUtil.flipPose(pose));
+				});
+				CORAL_SCORING_POSES_L4_BLUE_RIGHT.forEach((pose) -> {
+					CORAL_SCORING_POSES_L4_RED_RIGHT.add(PoseUtil.flipPose(pose));
 				});
 
 				// Generate a list of algae scoring poses.
@@ -838,6 +872,22 @@ public final class Constants {
 		 */
 		public static final List<Pose2d> CORAL_SCORING_POSES_RED_RIGHT = new ArrayList<Pose2d>();
 		/**
+		 * Poses from which the robot can score coral in L4 on the left side on the blue alliance.
+		 */
+		public static final List<Pose2d> CORAL_SCORING_POSES_L4_BLUE_LEFT = new ArrayList<Pose2d>();
+		/**
+		 * Poses from which the robot can score coral in L4 on the right side on the blue alliance.
+		 */
+		public static final List<Pose2d> CORAL_SCORING_POSES_L4_BLUE_RIGHT = new ArrayList<Pose2d>();
+		/**
+		 * Poses from which the robot can score coral in L4 on the left side on the red alliance.
+		 */
+		public static final List<Pose2d> CORAL_SCORING_POSES_L4_RED_LEFT = new ArrayList<Pose2d>();
+		/**
+		 * Poses from which the robot can score coral in L4 on the right side on the red alliance.
+		 */
+		public static final List<Pose2d> CORAL_SCORING_POSES_L4_RED_RIGHT = new ArrayList<Pose2d>();
+		/**
 		 * Poses from which the robot can score algae on the blue alliance.
 		 */
 		public static final List<Pose2d> ALGAE_SCORING_POSES_BLUE = new ArrayList<Pose2d>();
@@ -865,6 +915,26 @@ public final class Constants {
 			// Compile CORAL_SCORING_POSES_RED_RIGHT poses
 			FieldConstants.Reef.CORAL_SCORING_POSES_RED_RIGHT.forEach((pose) -> {
 				CORAL_SCORING_POSES_RED_RIGHT.add(pose);
+			});
+
+			// Compile CORAL_SCORING_POSES_L4_BLUE_LEFT poses
+			FieldConstants.Reef.CORAL_SCORING_POSES_L4_BLUE_LEFT.forEach((pose) -> {
+				CORAL_SCORING_POSES_L4_BLUE_LEFT.add(pose);
+			});
+
+			// Compile CORAL_SCORING_POSES_L4_BLUE_RIGHT poses
+			FieldConstants.Reef.CORAL_SCORING_POSES_L4_BLUE_RIGHT.forEach((pose) -> {
+				CORAL_SCORING_POSES_L4_BLUE_RIGHT.add(pose);
+			});
+
+			// Compile CORAL_SCORING_POSES_L4_RED_LEFT poses
+			FieldConstants.Reef.CORAL_SCORING_POSES_L4_RED_LEFT.forEach((pose) -> {
+				CORAL_SCORING_POSES_L4_RED_LEFT.add(pose);
+			});
+
+			// Compile CORAL_SCORING_POSES_L4_RED_RIGHT poses
+			FieldConstants.Reef.CORAL_SCORING_POSES_L4_RED_RIGHT.forEach((pose) -> {
+				CORAL_SCORING_POSES_L4_RED_RIGHT.add(pose);
 			});
 
 			// Compile ALGAE_SCORING_POSES_BLUE poses

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -706,7 +706,7 @@ public final class Constants {
 			/**
 			 * Offset from the AprilTag from which coral scoring into L4 should happen.
 			 */
-			public static final Transform2d CORAL_SCORING_OFFSET_L4 = new Transform2d(Meters.of(2.5), CORAL_SCORING_OFFSET.getMeasureY(), Rotation2d.k180deg);
+			public static final Transform2d CORAL_SCORING_OFFSET_L4 = new Transform2d(Meters.of(0.6), CORAL_SCORING_OFFSET.getMeasureY(), Rotation2d.k180deg);
 			/**
 			 * Offset from the AprilTag from which algae scoring should happen.
 			 */

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -848,6 +848,62 @@ public final class Constants {
 				ALGAE_SCORING_POSE_RED = PoseUtil.flipPoseAlliance(ALGAE_SCORING_POSE_BLUE);
 			}
 		}
+
+		/**
+		 * Constants relating to the coral station.
+		 */
+		public static class CoralStation {
+			/**
+			 * AprilTag ID for the coral station on the blue alliance.
+			 */
+			public static final int TAG_ID = 12;
+			/**
+			 * AprilTag pose for the coral station on the blue alliance.
+			 */
+			public static final Pose3d TAG_POSE;
+			/**
+			 * Offset from the AprilTag from which scoring should happen on the right side.
+			 */
+			public static final Transform2d SCORING_OFFSET = new Transform2d(Meters.of(0.33 / 2), Meters.of(0.5), Rotation2d.k180deg);
+			/**
+			 * Pose from which the robot can intake coral on the left side on the blue alliance.
+			 */
+			public static final Pose2d CORAL_SCORING_POSE_BLUE_LEFT;
+			/**
+			 * Pose from which the robot can intake coral on the right side on the blue alliance.
+			 */
+			public static final Pose2d CORAL_SCORING_POSE_BLUE_RIGHT;
+			/**
+			 * Pose from which the robot can intake coral on the left side on the red alliance.
+			 */
+			public static final Pose2d CORAL_SCORING_POSE_RED_LEFT;
+			/**
+			 * Pose from which the robot can intake coral on the right side on the red alliance.
+			 */
+			public static final Pose2d CORAL_SCORING_POSE_RED_RIGHT;
+
+			static {
+				// Find the tag pose.
+				Optional<Pose3d> tagPose = FIELD_LAYOUT.getTagPose(TAG_ID);
+
+				if (tagPose.isPresent()) {
+					TAG_POSE = tagPose.get();
+				} else {
+					TAG_POSE = new Pose3d();
+				}
+
+				// Generate scoring poses.
+				Pose2d pose2d = TAG_POSE.toPose2d();
+
+				// Generate scoring poses for the blue alliance.
+				CORAL_SCORING_POSE_BLUE_RIGHT = pose2d.transformBy(SCORING_OFFSET);
+				CORAL_SCORING_POSE_BLUE_LEFT = pose2d.transformBy(PoseUtil.flipTransformY(SCORING_OFFSET));
+
+				// Generate scoring poses for the red alliance.
+				CORAL_SCORING_POSE_RED_LEFT = PoseUtil.flipPoseAlliance(CORAL_SCORING_POSE_BLUE_LEFT);
+				CORAL_SCORING_POSE_RED_RIGHT = PoseUtil.flipPoseAlliance(CORAL_SCORING_POSE_BLUE_RIGHT);
+			}
+		}
 	}
 
 	/**
@@ -899,15 +955,19 @@ public final class Constants {
 		static {
 			// Compile CORAL_SCORING_POSES_BLUE_LEFT poses
 			CORAL_SCORING_POSES_BLUE_LEFT.addAll(FieldConstants.Reef.CORAL_SCORING_POSES_BLUE_LEFT);
+			CORAL_SCORING_POSES_BLUE_LEFT.add(FieldConstants.CoralStation.CORAL_SCORING_POSE_BLUE_LEFT);
 
 			// Compile CORAL_SCORING_POSES_BLUE_RIGHT poses
 			CORAL_SCORING_POSES_BLUE_RIGHT.addAll(FieldConstants.Reef.CORAL_SCORING_POSES_BLUE_RIGHT);
+			CORAL_SCORING_POSES_BLUE_RIGHT.add(FieldConstants.CoralStation.CORAL_SCORING_POSE_BLUE_RIGHT);
 
 			// Compile CORAL_SCORING_POSES_RED_LEFT poses
 			CORAL_SCORING_POSES_RED_LEFT.addAll(FieldConstants.Reef.CORAL_SCORING_POSES_RED_LEFT);
+			CORAL_SCORING_POSES_RED_LEFT.add(FieldConstants.CoralStation.CORAL_SCORING_POSE_RED_LEFT);
 
 			// Compile CORAL_SCORING_POSES_RED_RIGHT poses
 			CORAL_SCORING_POSES_RED_RIGHT.addAll(FieldConstants.Reef.CORAL_SCORING_POSES_RED_RIGHT);
+			CORAL_SCORING_POSES_RED_RIGHT.add(FieldConstants.CoralStation.CORAL_SCORING_POSE_RED_RIGHT);
 
 			// Compile CORAL_SCORING_POSES_L4_BLUE_LEFT poses
 			CORAL_SCORING_POSES_L4_BLUE_LEFT.addAll(FieldConstants.Reef.CORAL_SCORING_POSES_L4_BLUE_LEFT);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -151,12 +151,19 @@ public class RobotContainer {
 		driverController.leftTrigger()
 				.and(isAlgaeModeTrigger)
 				.whileTrue(Commands.either(drivetrain.driveToNearestPoseCommand(ScoringPoses.ALGAE_SCORING_POSES_RED), drivetrain.driveToNearestPoseCommand(ScoringPoses.ALGAE_SCORING_POSES_BLUE), () -> Util.isRedAlliance()));
+
 		driverController.leftTrigger()
 				.and(isCoralModeTrigger)
 				.whileTrue(Commands.either(drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_RED_LEFT), drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_BLUE_LEFT), () -> Util.isRedAlliance()));
 		driverController.rightTrigger()
 				.and(isCoralModeTrigger)
 				.whileTrue(Commands.either(drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_RED_RIGHT), drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_BLUE_RIGHT), () -> Util.isRedAlliance()));
+		driverController.leftBumper()
+				.and(isCoralModeTrigger)
+				.whileTrue(Commands.either(drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_L4_RED_LEFT), drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_L4_BLUE_LEFT), () -> Util.isRedAlliance()));
+		driverController.rightBumper()
+				.and(isCoralModeTrigger)
+				.whileTrue(Commands.either(drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_L4_RED_RIGHT), drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_L4_BLUE_RIGHT), () -> Util.isRedAlliance()));
 
 		driverController.start().onTrue(Commands.runOnce(() -> drivetrain.zeroGyro(), drivetrain));
 		driverController.back().onTrue(StubbedCommands.Drivetrain.DisableVision());

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -158,10 +158,10 @@ public class RobotContainer {
 		driverController.rightTrigger()
 				.and(isCoralModeTrigger)
 				.whileTrue(Commands.either(drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_RED_RIGHT), drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_BLUE_RIGHT), () -> Util.isRedAlliance()));
-		driverController.leftBumper()
+		driverController.povLeft()
 				.and(isCoralModeTrigger)
 				.whileTrue(Commands.either(drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_L4_RED_LEFT), drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_L4_BLUE_LEFT), () -> Util.isRedAlliance()));
-		driverController.rightBumper()
+		driverController.povRight()
 				.and(isCoralModeTrigger)
 				.whileTrue(Commands.either(drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_L4_RED_RIGHT), drivetrain.driveToNearestPoseCommand(ScoringPoses.CORAL_SCORING_POSES_L4_BLUE_RIGHT), () -> Util.isRedAlliance()));
 

--- a/src/main/java/frc/robot/util/PoseUtil.java
+++ b/src/main/java/frc/robot/util/PoseUtil.java
@@ -2,6 +2,7 @@ package frc.robot.util;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import frc.robot.Constants.FieldConstants;
 
@@ -17,8 +18,8 @@ public class PoseUtil {
 	 * @return
 	 *         Flipped pose.
 	 */
-	public static Pose2d flipPose(Pose2d pose) {
-		return new Pose2d(flipTranslation(pose.getTranslation()), pose.getRotation().rotateBy(Rotation2d.k180deg));
+	public static Pose2d flipPoseAlliance(Pose2d pose) {
+		return new Pose2d(flipTranslationAlliance(pose.getTranslation()), pose.getRotation().rotateBy(Rotation2d.k180deg));
 	}
 
 	/**
@@ -29,7 +30,19 @@ public class PoseUtil {
 	 * @return
 	 *         Flipped translation.
 	 */
-	public static Translation2d flipTranslation(Translation2d translation) {
+	public static Translation2d flipTranslationAlliance(Translation2d translation) {
 		return new Translation2d(FieldConstants.FIELD_LAYOUT.getFieldLength() - translation.getX(), FieldConstants.FIELD_LAYOUT.getFieldWidth() - translation.getY());
+	}
+
+	/**
+	 * Flips a transform across the Y axis.
+	 *
+	 * @param transform
+	 *            Transform to flip.
+	 * @return
+	 *         Flipped transform.
+	 */
+	public static Transform2d flipTransformY(Transform2d transform) {
+		return new Transform2d(transform.getMeasureX(), transform.getMeasureY().times(-1), transform.getRotation());
 	}
 }

--- a/src/main/java/frc/robot/util/PoseUtil.java
+++ b/src/main/java/frc/robot/util/PoseUtil.java
@@ -35,7 +35,7 @@ public class PoseUtil {
 	}
 
 	/**
-	 * Flips a transform across the Y axis.
+	 * Flips a transform across the X axis (inverts the Y axis).
 	 *
 	 * @param transform
 	 *            Transform to flip.


### PR DESCRIPTION
Adds a set of scoring poses for the coral station. The offset will need tuning before this is merged. The proximity of the coral station to the Reef may end up causing problems, since the closest pose may not be the one that the drivers intend, but if it is a problem I figure we could just add some variety of modes to separate intents to intake and outtake. It will take some testing to be sure, though.

This includes the changes from #173 because that refactors some things that this depends on, so if you are reviewing this on its own, just look at commit 9e51c3eee784c72a4f157a451c1a7aadb296b183.