### PR TITLE
Change the Limelight's tag ID filter based on alliance color

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -275,6 +275,14 @@ public final class Constants {
 		 * The {@link ImuMode} to use while enabled.
 		 */
 		public static final ImuMode ENABLED_IMU_MODE = ImuMode.ExternalAssistInternalIMU;
+		/**
+		 * The {@link io.github.roboblazers7617.limelight.LimelightSettings#withArilTagIdFilter(List)} to use on the blue alliance.
+		 */
+		public static final List<Double> BLUE_TAG_ID_FILTER = List.of(17.0, 18.0, 19.0, 20.0, 21.0, 22.0);
+		/**
+		 * The {@link io.github.roboblazers7617.limelight.LimelightSettings#withArilTagIdFilter(List)} to use on the Red alliance.
+		 */
+		public static final List<Double> RED_TAG_ID_FILTER = List.of(6.0, 7.0, 8.0, 9.0, 10.0, 11.0);
 	}
 
 	/**

--- a/src/main/java/frc/robot/Dashboard.java
+++ b/src/main/java/frc/robot/Dashboard.java
@@ -51,6 +51,7 @@ public class Dashboard {
 			new RunOnceDeferred(() -> {
 				configureAutoBuilder(alliance);
 			}).ignoringDisable(true).schedule();
+			drivetrain.getVision().setTagFilterAlliance(alliance);
 		});
 
 		pose = new SendableChooser<Pose2d>();

--- a/src/main/java/frc/robot/Dashboard.java
+++ b/src/main/java/frc/robot/Dashboard.java
@@ -48,6 +48,10 @@ public class Dashboard {
 
 		// TODO: #103 (Brandon) What happens if you change the color multiple times? Does this work or crash?
 		alliancePicker.onChange((alliance) -> {
+			if (alliance == null) {
+				System.err.println("BAD! Alliance chooser run without selected alliance");
+				return;
+			}
 			new RunOnceDeferred(() -> {
 				configureAutoBuilder(alliance);
 			}).ignoringDisable(true).schedule();
@@ -81,10 +85,6 @@ public class Dashboard {
 	 *            The alliance to configure the auto builder for.
 	 */
 	public void configureAutoBuilder(DriverStation.Alliance alliance) {
-		if (alliance == null) {
-			System.out.println("BAD! Allicance builder run without selected alliance");
-			return;
-		}
 		Auto.setupPathPlanner(drivetrain, alliance);
 		System.out.println("Configured path planner");
 

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -64,8 +64,8 @@ public class Vision {
 		previousHeading = swerveDrive.getOdometryHeading();
 
 		// Run enable command on enable
-		RobotModeTriggers.disabled()
-				.onFalse(onEnableCommand());
+		RobotModeTriggers.teleop()
+				.onTrue(onEnableCommand());
 	}
 
 	/*

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -94,19 +94,29 @@ public class Vision {
 			// Update the AprilTag ID filter
 			Optional<DriverStation.Alliance> alliance = DriverStation.getAlliance();
 			if (alliance.isPresent()) {
-				switch (alliance.get()) {
-					case Blue:
-						frontLimelight.settings.withArilTagIdFilter(VisionConstants.BLUE_TAG_ID_FILTER)
-								.save();
-						break;
-
-					case Red:
-						frontLimelight.settings.withArilTagIdFilter(VisionConstants.RED_TAG_ID_FILTER)
-								.save();
-						break;
-				}
+				setTagFilterAlliance(alliance.get());
 			}
 		});
+	}
+
+	/**
+	 * Sets the AprilTag ID filter to the appropriate set for the given alliance.
+	 *
+	 * @param alliance
+	 *            The alliance to set it for.
+	 */
+	public void setTagFilterAlliance(DriverStation.Alliance alliance) {
+		switch (alliance) {
+			case Blue:
+				frontLimelight.settings.withArilTagIdFilter(VisionConstants.BLUE_TAG_ID_FILTER)
+						.save();
+				break;
+
+			case Red:
+				frontLimelight.settings.withArilTagIdFilter(VisionConstants.RED_TAG_ID_FILTER)
+						.save();
+				break;
+		}
 	}
 
 	/**

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -62,11 +62,6 @@ public class Vision {
 
 		previousHeading = swerveDrive.getOdometryHeading();
 
-		// Set up alliance color mode switching
-		Util.isRedAllianceTrigger()
-				.onTrue(onRedAllianceCommand())
-				.onFalse(onBlueAllianceCommand());
-
 		// Set an alliance on enable
 		RobotModeTriggers.disabled()
 				.onFalse(Commands.either(onRedAllianceCommand(), onBlueAllianceCommand(), () -> Util.isRedAlliance()));

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -1,5 +1,7 @@
 package frc.robot.subsystems.vision;
 
+import java.util.Optional;
+
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
@@ -9,7 +11,6 @@ import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.RobotModeTriggers;
 
 import frc.robot.Constants.VisionConstants;
-import frc.robot.util.Util;
 
 import swervelib.SwerveDrive;
 import io.github.roboblazers7617.limelight.Limelight;
@@ -62,9 +63,9 @@ public class Vision {
 
 		previousHeading = swerveDrive.getOdometryHeading();
 
-		// Set an alliance on enable
+		// Run enable command on enable
 		RobotModeTriggers.disabled()
-				.onFalse(Commands.either(onRedAllianceCommand(), onBlueAllianceCommand(), () -> Util.isRedAlliance()));
+				.onFalse(onEnableCommand());
 	}
 
 	/*
@@ -81,28 +82,30 @@ public class Vision {
 	 */
 
 	/**
-	 * Command to call when the robot's alliance switches to the red alliance. Changes the AprilTag ID filter.
+	 * Command to call when the robot is enabled.
+	 * <p>
+	 * Updates the AprilTag ID filter.
 	 *
 	 * @return
 	 *         Command to run.
 	 */
-	private Command onRedAllianceCommand() {
+	private Command onEnableCommand() {
 		return Commands.runOnce(() -> {
-			frontLimelight.settings.withArilTagIdFilter(VisionConstants.RED_TAG_ID_FILTER)
-					.save();
-		});
-	}
+			// Update the AprilTag ID filter
+			Optional<DriverStation.Alliance> alliance = DriverStation.getAlliance();
+			if (alliance.isPresent()) {
+				switch (alliance.get()) {
+					case Blue:
+						frontLimelight.settings.withArilTagIdFilter(VisionConstants.BLUE_TAG_ID_FILTER)
+								.save();
+						break;
 
-	/**
-	 * Command to call when the robot's alliance switches to the blue alliance. Changes the AprilTag ID filter.
-	 *
-	 * @return
-	 *         Command to run.
-	 */
-	private Command onBlueAllianceCommand() {
-		return Commands.runOnce(() -> {
-			frontLimelight.settings.withArilTagIdFilter(VisionConstants.BLUE_TAG_ID_FILTER)
-					.save();
+					case Red:
+						frontLimelight.settings.withArilTagIdFilter(VisionConstants.RED_TAG_ID_FILTER)
+								.save();
+						break;
+				}
+			}
 		});
 	}
 

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -1,17 +1,17 @@
 package frc.robot.subsystems.vision;
 
+import java.util.Optional;
+
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Commands;
+
 import frc.robot.Constants.VisionConstants;
+
 import swervelib.SwerveDrive;
 import io.github.roboblazers7617.limelight.Limelight;
-import io.github.roboblazers7617.limelight.LimelightSettings;
 import io.github.roboblazers7617.limelight.PoseEstimator;
-import io.github.roboblazers7617.limelight.LimelightSettings.ImuMode;
 import io.github.roboblazers7617.limelight.PoseEstimate;
 
 /**
@@ -81,6 +81,21 @@ public class Vision {
 		// Get robot pose from YAGSL and use it to set the orientation in Limelight
 		frontLimelight.setRobotOrientation(new Rotation3d(swerveDrive.getOdometryHeading()));
 		// backLimelight.setRobotOrientation(swerveDrive.getGyroRotation3d());
+
+		// Set the tag filters in the Limelight
+		// TODO: This really shouldn't be done periodically. Not really sure where else to put it,
+		// but we should figure out something (maybe something when the robot enables or when the
+		// alliance color changes?).
+		Optional<DriverStation.Alliance> allianceColor = DriverStation.getAlliance();
+		switch (allianceColor.get()) {
+			case Red:
+				frontLimelight.settings.withArilTagIdFilter(VisionConstants.RED_TAG_ID_FILTER);
+				break;
+
+			case Blue:
+				frontLimelight.settings.withArilTagIdFilter(VisionConstants.BLUE_TAG_ID_FILTER);
+				break;
+		}
 
 		// Get pose estimates from Limelights
 		PoseEstimate[] frontLimelightPoseEstimates = frontPoseEstimator.getBotPoseEstimates();

--- a/src/main/java/frc/robot/util/Util.java
+++ b/src/main/java/frc/robot/util/Util.java
@@ -1,7 +1,6 @@
 package frc.robot.util;
 
 import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 /**
  * General utilities.
@@ -17,11 +16,4 @@ public class Util {
 		var alliance = DriverStation.getAlliance();
 		return alliance.isPresent() ? alliance.get() == DriverStation.Alliance.Red : false;
 	}
-
-	/**
-	 * Trigger for {@link #isRedAlliance()}.
-	 */
-	public static Trigger isRedAllianceTrigger() {
-		return new Trigger(() -> isRedAlliance());
-	};
 }

--- a/src/main/java/frc/robot/util/Util.java
+++ b/src/main/java/frc/robot/util/Util.java
@@ -1,6 +1,7 @@
 package frc.robot.util;
 
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 /**
  * General utilities.
@@ -16,4 +17,11 @@ public class Util {
 		var alliance = DriverStation.getAlliance();
 		return alliance.isPresent() ? alliance.get() == DriverStation.Alliance.Red : false;
 	}
+
+	/**
+	 * Trigger for {@link #isRedAlliance()}.
+	 */
+	public static Trigger isRedAllianceTrigger() {
+		return new Trigger(() -> isRedAlliance());
+	};
 }


### PR DESCRIPTION
Sets the Limelight's tag ID filter based on alliance color to the reef on the robot's alliance, both on enable and when the alliance color changes. I would like to get #155 merged before this, since the new version of ClassyLimelights fixes some things related to this which will require changes to this.

This has been tested to work in simulation, but still needs to be tested on the real robot hardware.