### PR TITLE
Use YAGSL for short-distance pathfinding

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -31,6 +31,7 @@ import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.trajectory.TrapezoidProfile.Constraints;
 import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.LinearAcceleration;
 
@@ -136,6 +137,40 @@ public final class Constants {
 			 * Maximum angular acceleration.
 			 */
 			public static final AngularAcceleration MAX_ANGULAR_ACCELERATION = DegreesPerSecondPerSecond.of(720);
+
+			/**
+			 * kP used for the YAGSL pathfinding translation PID controller.
+			 */
+			public static final double TRANSLATION_KP = 0.0;
+			/**
+			 * kI used for the YAGSL pathfinding translation PID controller.
+			 */
+			public static final double TRANSLATION_KI = 0.0;
+			/**
+			 * kD used for the YAGSL pathfinding translation PID controller.
+			 */
+			public static final double TRANSLATION_KD = 0.0;
+			/**
+			 * Constraints used for the YAGSL pathfinding translation PID controller.
+			 */
+			public static final Constraints TRANSLATION_CONSTRAINTS = new Constraints(0.0, 0.0);
+
+			/**
+			 * kP used for the YAGSL pathfinding rotation PID controller.
+			 */
+			public static final double ROTATION_KP = 0.0;
+			/**
+			 * kI used for the YAGSL pathfinding rotation PID controller.
+			 */
+			public static final double ROTATION_KI = 0.0;
+			/**
+			 * kD used for the YAGSL pathfinding rotation PID controller.
+			 */
+			public static final double ROTATION_KD = 0.0;
+			/**
+			 * Constraints used for the YAGSL pathfinding rotation PID controller.
+			 */
+			public static final Constraints ROTATION_CONSTRAINTS = new Constraints(0.0, 0.0);
 		}
 
 		/**

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainControls.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainControls.java
@@ -3,6 +3,8 @@ package frc.robot.subsystems.drivetrain;
 import java.util.function.Supplier;
 import frc.robot.Constants.DrivetrainConstants;
 import frc.robot.Constants.OperatorConstants;
+import edu.wpi.first.math.controller.ProfiledPIDController;
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.Command;
@@ -21,6 +23,14 @@ public class DrivetrainControls {
 	 * Speed multiplier used for scaling controller inputs (0, 1].
 	 */
 	private double speedMultiplier;
+	/**
+	 * The PID controller used for translation while pathfinding.
+	 */
+	private final ProfiledPIDController pathfindingTranslationPidController;
+	/**
+	 * The PID controller used for rotation while pathfinding.
+	 */
+	private final ProfiledPIDController pathfindingRotationPidController;
 
 	/**
 	 * Creates a new DrivetrainControls.
@@ -30,6 +40,10 @@ public class DrivetrainControls {
 	 */
 	public DrivetrainControls(Drivetrain drivetrain) {
 		this.drivetrain = drivetrain;
+
+		// Create PID controllers for pathfinding
+		pathfindingTranslationPidController = new ProfiledPIDController(DrivetrainConstants.Pathfinding.TRANSLATION_KP, DrivetrainConstants.Pathfinding.TRANSLATION_KI, DrivetrainConstants.Pathfinding.TRANSLATION_KD, DrivetrainConstants.Pathfinding.TRANSLATION_CONSTRAINTS);
+		pathfindingRotationPidController = new ProfiledPIDController(DrivetrainConstants.Pathfinding.ROTATION_KP, DrivetrainConstants.Pathfinding.ROTATION_KI, DrivetrainConstants.Pathfinding.ROTATION_KD, DrivetrainConstants.Pathfinding.ROTATION_CONSTRAINTS);
 
 		// Set things to their default states
 		resetSpeedMultiplier();
@@ -138,6 +152,22 @@ public class DrivetrainControls {
 	}
 
 	/**
+	 * A copy of {@link #driveGeneric(CommandXboxController)} that pathfinds to a given pose.
+	 *
+	 * @param controller
+	 *            The controller to read from.
+	 * @param pose
+	 *            The pose to pathfind to.
+	 * @return
+	 *         SwerveInputStream with data from the controller.
+	 */
+	public SwerveInputStream drivePathfind(CommandXboxController controller, Supplier<Pose2d> pose) {
+		return driveGeneric(controller)
+				.driveToPose(pose, pathfindingTranslationPidController, pathfindingRotationPidController)
+				.driveToPoseEnabled(true);
+	}
+
+	/**
 	 * {@link #driveInputStreamScaledCommand(SwerveInputStream)} that uses {@link #driveAngularVelocity(CommandXboxController)}. Calls {@link Drivetrain#resetLastAngleScalar()} on end to prevent snapback.
 	 *
 	 * @param controller
@@ -172,5 +202,19 @@ public class DrivetrainControls {
 	 */
 	public Command driveFieldOrientedDirectAngleSimCommand(CommandXboxController controller) {
 		return driveInputStreamScaledCommand(driveDirectAngleSim(controller));
+	}
+
+	/**
+	 * {@link Drivetrain#driveFieldOrientedCommand(Supplier)} that uses {@link DrivetrainControls#drivePathfind(CommandXboxController, Supplier)}.
+	 *
+	 * @param controller
+	 *            Controller to use.
+	 * @param pose
+	 *            Pose to pathfind to.
+	 * @return
+	 *         Command to run.
+	 */
+	public Command driveFieldOrientedPathfindCommand(CommandXboxController controller, Supplier<Pose2d> pose) {
+		return drivetrain.driveFieldOrientedCommand(drivePathfind(controller, pose));
 	}
 }


### PR DESCRIPTION
Switch to SwerveInputStream pathfinding when within a short distance of the target pose.